### PR TITLE
Adds support for using an arbitrary branch to trigger releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # terraform-aws-codecommit-releases
 
-Tag an AWS CodeCommit repo when the version is incremented in the default
+Tag an AWS CodeCommit repo when the version is incremented in the release
 branch.
 
 Tags are often used to mark a release, but the version is often maintained in a
@@ -8,7 +8,7 @@ file in the repo. This project helps automate the creation of the tag, based on
 changes to such a file.
 
 This Terraform module creates a CloudWatch Event and a CodeBuild Project. The
-Event triggers the CodeBuild Project whenever the repo's default branch is
+Event triggers the CodeBuild Project whenever the repo's release branch is
 updated (`referenceUpdated`). The CodeBuild Job checks the version, and creates
 a tag if the version has incremented.
 
@@ -28,26 +28,13 @@ module "codecommit-releases" {
   source = "git::https://github.com/plus3it/terraform-aws-codecommit-releases.git"
 
   codecommit_repo_name    = "foo"  # This is the only required parameter
-  default_branch          = "master"
+  release_branch          = "master"
   prior_version_command   = "git describe --abbrev=0 --tags"
   release_version_command = "grep '^current_version' $CODEBUILD_SRC_DIR/.bumpversion.cfg | sed 's/^.*= //'"
 }
 ```
 
 ## Limitations
-
-### Default Branch
-
-The branch to trigger on can be specified using the variable `default_branch`,
-but the Cloudwatch Event cannot pass params to the CodeBuild job. That means
-the CodeBuild job will only execute on the actual default branch.
-
-If you specify a branch other than the default, the Event will trigger the job
-on changes to that non-default branch, but CodeBuild will still pull the actual
-default branch.
-
-Changes to the version file in the non-default branch will not result in a new
-tag.
 
 ### Semantic Versioning
 

--- a/variables.tf
+++ b/variables.tf
@@ -3,9 +3,9 @@ variable "codecommit_repo_name" {
   description = "Name of the CodeCommit repository"
 }
 
-variable "default_branch" {
+variable "release_branch" {
   type        = "string"
-  description = "Name of the default branch"
+  description = "Name of the release branch"
   default     = "master"
 }
 


### PR DESCRIPTION
Previously, the default_branch would match the CloudWatch Event,
which would trigger the build, but the branch value wasn't
available to the job so it always executed on the actual default
branch.

This patch passes the value through the CodeBuild environment, and
checks out the specified branch prior to running the versioning
commands. This allows this module to use any arbitrary branch to
trigger a release.

The var name is changed from default_branch to release_branch to
better indicate the capability.